### PR TITLE
Add 'data' param to EIP-1559 to allow contract calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,6 @@ from aws_cdk import App
 from aws_kms_lambda_ethereum.aws_kms_lambda_ethereum_stack import AwsKmsLambdaEthereumStack
 
 app = App()
-AwsKmsLambdaEthereumStack(app, "aws-kms-lambda-ethereum")
+AwsKmsLambdaEthereumStack(app, "minter10")
 
 app.synth()

--- a/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_function.py
+++ b/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_function.py
@@ -58,6 +58,8 @@ def lambda_handler(event, context):
         amount = event.get('amount')
 
         nonce = event.get('nonce')
+        # get the call data
+        data = event.get('data')
 
         # optional params
         chainid = event.get('chainid')
@@ -78,7 +80,8 @@ def lambda_handler(event, context):
                                   chainid=chainid,
                                   type=type,
                                   max_fee_per_gas=max_fee_per_gas,
-                                  max_priority_fee_per_gas=max_priority_fee_per_gas)
+                                  max_priority_fee_per_gas=max_priority_fee_per_gas,
+                                  data=data)
 
         # assemble Ethereum transaction and sign it offline
         raw_tx_signed_hash, raw_tx_signed_payload = assemble_tx(tx_params=tx_params,

--- a/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_function.py
+++ b/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_function.py
@@ -64,6 +64,7 @@ def lambda_handler(event, context):
         # optional params
         chainid = event.get('chainid')
         type = event.get('type')
+        gas_limit = event.get('gas_limit')
         max_fee_per_gas = event.get('max_fee_per_gas')
         max_priority_fee_per_gas = event.get('max_priority_fee_per_gas')
 
@@ -79,6 +80,7 @@ def lambda_handler(event, context):
                                   nonce=nonce,
                                   chainid=chainid,
                                   type=type,
+                                  gas_limit=gas_limit,
                                   max_fee_per_gas=max_fee_per_gas,
                                   max_priority_fee_per_gas=max_priority_fee_per_gas,
                                   data=data)

--- a/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_function.py
+++ b/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_function.py
@@ -44,9 +44,14 @@ def lambda_handler(event, context):
     #  "nonce": 0}
     elif operation == 'sign':
 
-        if not (event.get('dst_address') and event.get('amount', -1) >= 0 and event.get('nonce', -1) >= 0):
+        # dst_address is optional for CONTRACT CREATION: when it is absent,
+        # `data` must carry the init code and the signed tx omits the `to`
+        # field entirely. (An empty `to` is what makes the network execute
+        # `data` as init code — the zero address would be a regular call
+        # that burns the payload.)
+        if not ((event.get('dst_address') or event.get('data')) and event.get('amount', -1) >= 0 and event.get('nonce', -1) >= 0):
             return {'operation': 'sign',
-                    'error': 'missing parameter - sign requires amount, dst_address and nonce to be specified'}
+                    'error': 'missing parameter - sign requires amount, nonce and either dst_address or data (contract creation) to be specified'}
 
         # get key_id from environment varaible
         key_id = os.getenv('KMS_KEY_ID')

--- a/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_helper.py
+++ b/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_helper.py
@@ -151,12 +151,12 @@ def get_recovery_id(msg_hash: bytes, r: int, s: int, eth_checksum_addr: str, cha
 
 
 def get_tx_params(dst_address: str, amount: int, nonce: int,
-                  chainid: int, type: int, max_fee_per_gas: int, max_priority_fee_per_gas: int) -> dict:
+                  chainid: int, type: int, max_fee_per_gas: int, max_priority_fee_per_gas: int, data: str) -> dict:
     transaction = {
         'nonce': nonce,
         'to': dst_address,
         'value': w3.toWei(amount, 'ether'),
-        'data': '0x00',
+        'data': data,
         'gas': 160000,
         'maxFeePerGas': max_fee_per_gas,
         'maxPriorityFeePerGas': max_priority_fee_per_gas,

--- a/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_helper.py
+++ b/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_helper.py
@@ -154,7 +154,6 @@ def get_tx_params(dst_address: str, amount: int, nonce: int,
                   chainid: int, type: int, gas_limit: int, max_fee_per_gas: int, max_priority_fee_per_gas: int, data: str) -> dict:
     transaction = {
         'nonce': nonce,
-        'to': dst_address,
         'value': w3.toWei(amount, 'ether'),
         'data': data,
         'gas': gas_limit,
@@ -163,6 +162,12 @@ def get_tx_params(dst_address: str, amount: int, nonce: int,
         'type': type,
         'chainId': chainid,
     }
+
+    # CONTRACT CREATION: omit `to` entirely when no destination is given —
+    # eth-account then encodes an empty `to` field (allow_empty=True with an
+    # empty default) and the network executes `data` as init code.
+    if dst_address:
+        transaction['to'] = dst_address
 
     return transaction
 

--- a/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_helper.py
+++ b/aws_kms_lambda_ethereum/_lambda/functions/eth_client_eip1559/lambda_helper.py
@@ -151,13 +151,13 @@ def get_recovery_id(msg_hash: bytes, r: int, s: int, eth_checksum_addr: str, cha
 
 
 def get_tx_params(dst_address: str, amount: int, nonce: int,
-                  chainid: int, type: int, max_fee_per_gas: int, max_priority_fee_per_gas: int, data: str) -> dict:
+                  chainid: int, type: int, gas_limit: int, max_fee_per_gas: int, max_priority_fee_per_gas: int, data: str) -> dict:
     transaction = {
         'nonce': nonce,
         'to': dst_address,
         'value': w3.toWei(amount, 'ether'),
         'data': data,
-        'gas': 160000,
+        'gas': gas_limit,
         'maxFeePerGas': max_fee_per_gas,
         'maxPriorityFeePerGas': max_priority_fee_per_gas,
         'type': type,

--- a/aws_kms_lambda_ethereum/aws_kms_lambda_ethereum_stack.py
+++ b/aws_kms_lambda_ethereum/aws_kms_lambda_ethereum_stack.py
@@ -19,7 +19,8 @@ class EthLambda(Construct):
                  scope: Construct,
                  id: str,
                  dir: str,
-                 env: dict
+                 env: dict,
+                 name: str
                  ):
         super().__init__(scope, id)
 
@@ -40,6 +41,7 @@ class EthLambda(Construct):
         lf = aws_lambda.Function(
             self,
             "Function",
+            function_name=name,
             handler="lambda_function.lambda_handler",
             runtime=aws_lambda.Runtime.PYTHON_3_9,
             environment=env,
@@ -58,6 +60,11 @@ class AwsKmsLambdaEthereumStack(Stack):
 
         cmk = aws_kms.Key(self, "eth-cmk-identity",
                           removal_policy=RemovalPolicy.DESTROY)
+        
+        aws_kms.Alias(self, "eth-cmk-alias",
+              alias_name="alias/minter10-identity",  # Must start with "alias/"
+              target_key=cmk)
+
         cfn_cmk = cmk.node.default_child
         cfn_cmk.key_spec = 'ECC_SECG_P256K1'
         cfn_cmk.key_usage = 'SIGN_VERIFY'
@@ -67,7 +74,8 @@ class AwsKmsLambdaEthereumStack(Stack):
                                env={"LOG_LEVEL": "DEBUG",
                                     "KMS_KEY_ID": cmk.key_id,
                                     "ETH_NETWORK": eth_network
-                                    }
+                                    },
+                                name="minter10-client"
                                )
 
         cmk.grant(eth_client.lf, 'kms:GetPublicKey')
@@ -78,7 +86,8 @@ class AwsKmsLambdaEthereumStack(Stack):
                                        env={"LOG_LEVEL": "DEBUG",
                                             "KMS_KEY_ID": cmk.key_id,
                                             "ETH_NETWORK": eth_network
-                                            }
+                                            },
+                                        name="minter10-eip1559"
                                        )
 
         cmk.grant(eth_client_eip1559.lf, 'kms:GetPublicKey')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is a very simple change that adds a 'data' param to the EIP-1559 lambda function so contract calls can be made. Thank you very much for this example, it was extremely helpful.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
