### PR TITLE
Update default Ethereum network to Sepolia and relevant links

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ This repository represents a PoC of how Ethereum accounts (private/public key) c
 KMS can be used to create valid offline signatures on Ethereum transactions.
 
 In this simple example, a transaction is created to send some Ether from one Ethereum account to another. For testing
-purposes it is recommended to use Ethereum Rinkeby (`https://www.rinkeby.io`) network for example and to create an
-account via Metamask.
+purposes it is recommended to use Ethereum Sepolia (https://chainlist.org/chain/11155111) network for example and to create an account via Metamask.
 
-To bootstrap the AWS KMS-CMK based Ethereum account, the Rinkeby crypto faucet can be
-used (https://www.rinkeby.io/#faucet).
+To bootstrap the AWS KMS-CMK based Ethereum account, Sepolia test Ether can be obtained from the following faucets:
+- Alchemy: https://sepoliafaucet.com/
+- QuickNode: https://faucet.quicknode.com/ethereum/sepolia
+- Infura: https://www.infura.io/faucet/sepolia
 
 ---------------------
 

--- a/aws_kms_lambda_ethereum/aws_kms_lambda_ethereum_stack.py
+++ b/aws_kms_lambda_ethereum/aws_kms_lambda_ethereum_stack.py
@@ -53,7 +53,7 @@ class EthLambda(Construct):
 
 class AwsKmsLambdaEthereumStack(Stack):
 
-    def __init__(self, scope: Construct, construct_id: str, eth_network: str = 'rinkeby', **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, eth_network: str = 'sepolia', **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         cmk = aws_kms.Key(self, "eth-cmk-identity",


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Updated outdated Sepolia faucet links in the README file.  
Previously, the README referenced a non-existent URL (`https://www.sepolia.io/#faucet`).  
This has been replaced with currently active and recommended faucet links:

- Alchemy: https://sepoliafaucet.com/
- QuickNode: https://faucet.quicknode.com/ethereum/sepolia
- Infura: https://www.infura.io/faucet/sepolia

This change improves documentation accuracy and developer onboarding experience for testing on the Sepolia network.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
